### PR TITLE
Improve README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,13 +8,40 @@ This allows VICE to command an Elektron SIDStation, or a C64 with a Vessel inter
 or a C64 with a regular MIDI interface and [Station64](https://csdb.dk/release/?id=142049).  ASID isn't fast enough for sample playback.
 
 ## Building
-
+### Installing build dependencies
 ```
-sudo apt-get update && sudo apt-get install -y libasound2-dev
-./autogen.sh && ./configure --with-alsa && make -j && sudo make install
+sudo apt update && sudo apt install \
+	autoconf \
+	build-essential \
+	byacc \
+	dos2unix \
+	flex \
+	libasound2-dev \
+	libglew-dev \
+	libglib2.0-dev \
+	libpng-dev \
+	libsdl2-dev \
+	libsdl2-image-dev \
+	texinfo \
+	texmaker \
+	xa65
+```
+
+### Compiling 
+```
+./autogen.sh && ./configure --with-alsa && make -j
+```
+
+### Installing
+```
+sudo make install
 ```
 
 ## Running
+To enable the asid output, use the `-sounddev asid` command line option.
+Select the midi port to use with `-soundarg`.
+The list of ports is output when the asid driver is started (either on the command line, or in vice.log)
+It defaults to port 0, which is usually some internal port.
 
 ```
 vsid -sounddev asid -soundarg 1 Commando.sid
@@ -22,4 +49,10 @@ vsid -sounddev asid -soundarg 1 Commando.sid
 
 ```
 x64sc -sounddev asid -soundarg 1 Commando.d64
+```
+
+The midi port can also be set in `vice.ini`:
+```
+SoundDeviceName="asid"
+SoundDeviceArg="1"
 ```


### PR DESCRIPTION
Hi! I decided to offer some (imo) improvements to the README that may be useful for more novice users.

When trying to build this on Ubuntu Jammy Jellyfish 22.04.2 LTS I noticed that I had to install more dependencies than `libasound2-dev`. After I made it work I tried it on a completely fresh install of that OS and gathered every package that was needed to successfully build:
- autoconf
- build-essential
- byacc
- dos2unix
- flex
- libasound2-dev
- libglew-dev
- libglib2.0-dev
- libpng-dev
- libsdl2-dev
- libsdl2-image-dev
- texinfo
- texmaker
- xa65

While I was at it I tried to improve the README further:
- using apt instead of apt-get (I think this is recommended nowadays)
- removing -y flag for apt (to give users a chance to review download size, etc)
- splitting the build steps a bit apart (not everyone might want to `install` it, for example)
- added the usage instructions from the forum post to the `Running` section