### PR TITLE
log: fix log_file_close use-after-free (revice patch 07)

### DIFF
--- a/src/log.c
+++ b/src/log.c
@@ -171,10 +171,10 @@ static void log_file_close(void)
 {
     DBG(("log_file_close %p\n", log_file));
     if (log_file) {
+        fflush(log_file);
         if (log_file != stdout) {
             fclose(log_file);
         }
-        fflush(log_file);
         log_file = NULL;
     }
 }


### PR DESCRIPTION
Propagates the use-after-free fix from revice into asid-vice.

## Changes
- **`src/revice`**: bump submodule `842d9e6` → `23c8300` (revice `main`), which adds `integration/vice/patches/07-log-file-close-use-after-free.patch`.
- **`src/log.c`**: bake that patch into the tree (flush before close), matching how the other revice edits are carried in-tree.

## Why

`log_file_close()` did:

```c
if (log_file != stdout) {
    fclose(log_file);   // frees the FILE*
}
fflush(log_file);       // use-after-free
```

When the log file isn't stdout, `fflush` writes to the freed 472-byte FILE struct, corrupting glibc's malloc tcache (bin 28). The corruption detonates at the next same-size allocation — the `fopen()` of the SID file in `try_uncompress_lynx()` — so vsid segfaults in an unrelated spot, intermittently (ASLR-dependent, ~50–66%). Downstream (vsiddump.py) the crashed vsid leaves the fifo reader hung.

Diagnosed with gdb (4 identical backtraces: crash in `tcache_get_n` ← `malloc(472)` ← `fopen` ← `try_uncompress_lynx`) and valgrind (invalid read/write of the freed log FILE in `log_file_close`).

This is a stock VICE bug (identical in `VICE-Team/svn-mirror`); carried here via revice since upstream doesn't take outside patches.

## Verification

headlessvice image rebuilt with the fix: a SID that previously crashed ~50–66% of runs now dumps **30/30**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)