### PR TITLE
feat(bustrace): wire revice CPU bus-trace into VSID

### DIFF
--- a/src/c64/Makefile.am
+++ b/src/c64/Makefile.am
@@ -303,3 +303,10 @@ AM_CPPFLAGS += -I$(top_srcdir)/src/revice/libs/screen/include -I$(top_srcdir)/sr
 AM_CPPFLAGS += -I$(top_srcdir)/src/revice/libs/keymatrix/vice
 libc64sc_a_SOURCES += $(top_srcdir)/src/revice/libs/screen/vice/c64screen.c
 # <<< revice wiring <<<
+
+# >>> revice wiring: bustrace (managed by apply-wiring.sh) >>>
+AM_CPPFLAGS += -I$(top_srcdir)/src/revice/libs/bustrace/include -I$(top_srcdir)/src/revice/libs/bustrace/vice
+libvsid_a_SOURCES += \
+	$(top_srcdir)/src/revice/libs/bustrace/src/bustrace_core.c \
+	$(top_srcdir)/src/revice/libs/bustrace/vice/soundbustrace.c
+# <<< revice wiring: bustrace <<<

--- a/src/c64/vsid.c
+++ b/src/c64/vsid.c
@@ -71,6 +71,8 @@
 #include "vsid-debugcart.h"
 #include "vsync.h"
 
+#include "soundbustrace.h"
+
 
 machine_context_t machine_context;
 
@@ -127,6 +129,10 @@ int machine_resources_init(void)
         init_resource_fail("debug cart");
         return -1;
     }
+    if (bustrace_resources_init() < 0) {
+        init_resource_fail("bustrace");
+        return -1;
+    }
 #ifdef DEBUG
     if (debug_resources_init() < 0) {
         init_resource_fail("debug");
@@ -165,6 +171,10 @@ int machine_cmdline_options_init(void)
     }
     if (debugcart_cmdline_options_init() < 0) {
         init_cmdline_options_fail("debug cart");
+        return -1;
+    }
+    if (bustrace_cmdline_options_init() < 0) {
+        init_cmdline_options_fail("bustrace");
         return -1;
     }
     return 0;
@@ -289,6 +299,8 @@ void machine_specific_shutdown(void)
 {
     ciacore_shutdown(machine_context.cia1);
     ciacore_shutdown(machine_context.cia2);
+
+    bustrace_shutdown();
 
     /* close the video chip(s) */
     vicii_shutdown();

--- a/src/c64/vsidcpu.c
+++ b/src/c64/vsidcpu.c
@@ -33,6 +33,8 @@
 #include "c64pla.h"
 #endif
 
+#include "soundbustrace.h"
+
 /* ------------------------------------------------------------------------- */
 
 /* MACHINE_STUFF should define/undef
@@ -63,6 +65,8 @@ static void memmap_mem_store(unsigned int addr, unsigned int value)
     } else {
         monitor_memmap_store(addr, MEMMAP_RAM_W);
     }
+    bustrace_observe_access((uint16_t)addr, (uint8_t)value,
+                            REVICE_BUSTRACE_RW_WRITE);
     (*_mem_write_tab_ptr[(addr) >> 8])((uint16_t)(addr), (uint8_t)(value));
 }
 
@@ -73,6 +77,8 @@ static void memmap_mem_store_dummy(unsigned int addr, unsigned int value)
     } else {
         monitor_memmap_store(addr, MEMMAP_RAM_W);
     }
+    bustrace_observe_access((uint16_t)addr, (uint8_t)value,
+                            REVICE_BUSTRACE_RW_WRITE | REVICE_BUSTRACE_RW_DUMMY);
     (*_mem_write_tab_ptr_dummy[(addr) >> 8])((uint16_t)(addr), (uint8_t)(value));
 }
 
@@ -103,14 +109,22 @@ static void memmap_mark_read(unsigned int addr)
 
 static uint8_t memmap_mem_read(unsigned int addr)
 {
+    uint8_t bustrace_rw = (memmap_state & MEMMAP_STATE_OPCODE)
+                          ? REVICE_BUSTRACE_RW_OPCODE : 0;
+    uint8_t value;
     memmap_mark_read(addr);
-    return (*_mem_read_tab_ptr[(addr) >> 8])((uint16_t)(addr));
+    value = (*_mem_read_tab_ptr[(addr) >> 8])((uint16_t)(addr));
+    bustrace_observe_access((uint16_t)addr, value, bustrace_rw);
+    return value;
 }
 
 static uint8_t memmap_mem_read_dummy(unsigned int addr)
 {
+    uint8_t value;
     memmap_mark_read(addr);
-    return (*_mem_read_tab_ptr_dummy[(addr) >> 8])((uint16_t)(addr));
+    value = (*_mem_read_tab_ptr_dummy[(addr) >> 8])((uint16_t)(addr));
+    bustrace_observe_access((uint16_t)addr, value, REVICE_BUSTRACE_RW_DUMMY);
+    return value;
 }
 #endif
 


### PR DESCRIPTION
## What

Adds the **`-bustrace <file>`** feature: during VSID playback, record the full 6510 bus — every memory access `{cycle, addr, val, rw, pc}` — to a deterministic binary trace alongside the existing SID-register dump. Provenance substrate for generic BACC recovery; **replaces the dropped, non-deterministic libsidplayfp `sidtrace` `.bus.bin`** (its output varied run-to-run on the same tune and broke byte-exact gates).

Trace logic lives in the revice `libs/bustrace` core (pure C, unit-tested with no VICE build, merged in anarkiwi/revice#7). This PR:

- bumps the `src/revice` submodule to the merged bustrace core + adapter,
- wires the adapter (`soundbustrace.c`) + core (`bustrace_core.c`) into `libvsid.a` (`src/c64/Makefile.am`),
- adds the per-access hook in `src/c64/vsidcpu.c`'s `FEATURE_CPUMEMHISTORY` memmap functions (the existing per-access observation point — captures the real bus value, opcode-fetch bit, and dummy/internal flag),
- registers the `BusTraceFile` resource / `-bustrace` cmdline option + the shutdown finalize in `src/c64/vsid.c`.

## Non-perturbing / additive

With no `-bustrace` file the hot path is a single null-pointer test, so the SID-register dump (`-sounddev dump` → `.dump.parquet` ground truth) is **byte-identical** with the feature off vs on. We only read bus values and append to a separate file; emulation and the dump are untouched. Build with `--enable-cpuhistory`.

## Trace format (v1)

`header(16) · record(10)* · trailer(16)`, all little-endian: header carries magic/version/`cycles_per_sec`; each record is `cycle_delta:u32, addr:u16, val:u8, rw_flags:u8, pc:u16`; the trailer carries a record count + CRC-32 over the records so a reader can verify completeness. Cycles are delta-encoded (running sum recovers absolute). See `src/revice/libs/bustrace/include/revice_bustrace.h`.

## Determinism

The core does no allocation / time / RNG / float, all little-endian by hand → byte-identical output across runs (the property sidtrace lacked), asserted in the revice unit test. asid-vice's emulation is itself deterministic, so the same tune → the same trace.

## Build note

The adapter + core **compile clean** against the VICE headers (headless arch, `-Wall -Wextra`). Re-run `./autogen.sh` to regenerate `Makefile.in` before `make vsid` (the committed change is to `Makefile.am`).

## Validation status / why not auto-merged

- revice core determinism: proven by unit test (CTest green).
- revice integration-build CI (revice#7): green — cores + adapters compile and archive into the VICE libs with bustrace wired in.
- On-emulator determinism + dump-unchanged + completeness on Monty / Grid_Runner: **runbook pending** (the landing sandbox lacked the full VSID build deps: alsa/glib/xa65). See `design/infra/vice_bustrace_observation.md` in preframr-xpt. Merge once those numbers are captured.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MRVf3WC7UuohdsvZGd7ed2