### PR TITLE
log: fix stdout NULL deref / heap corruption (revice patch 09)

### DIFF
--- a/src/log.c
+++ b/src/log.c
@@ -760,6 +760,17 @@ static int log_helper(log_t log, unsigned int level, const char *format,
         /* FIXME: we should force colors off here, if the standard logger goes
                   into a file (because stdout was redirected) */
         if (archdep_default_logger_is_terminal() == 0) {
+            /* The non-colorized strings are only built above when log_to_file is
+               set or colorizing is off. When neither holds (e.g. +logtofile with
+               colorizing on) but stdout is not a terminal, they are still NULL
+               here - build them now so log_archdep() never strlen()s a NULL
+               pointer (which segfaults / corrupts the heap). */
+            if (nocolorpre == NULL) {
+                nocolorpre = logskipcolors(pretxt);
+            }
+            if (nocolortxt == NULL) {
+                nocolortxt = logskipcolors(logtxt);
+            }
             terminalpre = nocolorpre;
             terminaltxt = nocolortxt;
         }


### PR DESCRIPTION
Carries revice patch 09 (anarkiwi/revice#9) applied in-tree, mirroring how patch 07 landed via #38.

## Problem

After headlessvice enabled \`--enable-cpuhistory\` (required for the bustrace per-access hook), preframr-tokens CI dump rendering began crashing intermittently (vsid ~27s into the Monty full-songlength dump), reproducing only on some hosts — a heap-layout/ASLR-dependent latent bug.

## Root cause (ASAN-confirmed)

Pre-existing NULL deref in stock VICE \`src/log.c\`, merely exposed by the changed heap layout. \`log_helper()\` only builds the non-colorized copies \`nocolorpre\`/\`nocolortxt\` when \`(log_to_file || !log_colorize)\`, but the stdout branch switches to them whenever the default logger is not a terminal (stdout is a pipe). The headlessvice/vsiddump.py invocation uses \`+logtofile +logtostdout\` with \`LogColorize\` defaulting to 1, so both are NULL → \`log_archdep()\` calls \`strlen(NULL)\`.

\`\`\`
ERROR: AddressSanitizer: SEGV on unknown address 0x000000000000
  #1 strlen
  #2 log_archdep src/log.c:615
  #3 log_helper  src/log.c:767
  #4 log_printf  src/log.c:903
\`\`\`

## Fix

Lazily build the non-colorized strings in the stdout branch if not already built. \`logskipcolors()\` never returns NULL; existing \`lib_free()\`s already cover them.

## Verification

ASAN vsid build (\`--enable-cpuhistory\`, revice wired): SEGV reproduces deterministically before; ASAN-clean 5/5 full-songlength Monty dumps after; SID register dump byte-identical (md5 \`f4fe2c887cc892b6c0aa673c6c5ea0fb\`); \`-bustrace\` \`.bus.bin\` valid (\`RBT1\`) and deterministic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MRVf3WC7UuohdsvZGd7ed2