### PR TITLE
Dockerfile: install `file` (required by infocontrib.h build rule)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -82,6 +82,9 @@ src/monitor/mon_parse.h
 
 # --- documentation build outputs -----------------------------------------
 doc/html/*.html
+# ...but doc/html/index.html is checked-in *source* that src/Makefile.am's
+# infocontrib.h rule reads (it `cp`s it), so the build needs it in context.
+!doc/html/index.html
 doc/html/*.png
 doc/html/COPYING
 doc/html/NEWS

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,3 +10,15 @@ jobs:
           submodules: recursive
       - name: test build
         run: ./build.sh
+
+  docker-build:
+    # Build the headless binmon image so the Dockerfile itself is exercised
+    # (build.sh above runs on the runner, which ships utilities the slim base
+    # image does not, so it does not catch missing Dockerfile build deps).
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          submodules: recursive
+      - name: docker build
+        run: docker build -t asid-vice:latest .

--- a/Dockerfile
+++ b/Dockerfile
@@ -34,7 +34,9 @@ ENV DEBIAN_FRONTEND=noninteractive
 
 # Build deps. SDL/GLEW/GTK are *not* needed for --enable-headlessui, but
 # we keep libpng (for screenshot subsystem) and libasound (for the audio
-# pipeline; harmless even when no device is attached).
+# pipeline; harmless even when no device is attached). `file` is required by
+# src/Makefile.am's infocontrib.h rule (`file --mime-encoding`); the slim base
+# image does not ship it, unlike the Ubuntu CI runner that runs build.sh.
 RUN apt-get update && apt-get install -y --no-install-recommends \
         autoconf \
         automake \
@@ -42,6 +44,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         byacc \
         ca-certificates \
         dos2unix \
+        file \
         flex \
         libasound2-dev \
         libcurl4-openssl-dev \


### PR DESCRIPTION
The headless image builds on `debian:bookworm-slim`, which does not ship the
`file` utility. VICE's `src/Makefile.am` infocontrib.h rule runs
`file --mime-encoding` to validate the generated header's encoding, so
`docker build .` fails with:

```
/bin/bash: line 1: file: command not found
ERROR: geninfocontrib_h.sh contains content that is not valid iso-8859-x
```

This was never caught in CI because `.github/workflows/test.yml` runs
`build.sh` directly on the GitHub `ubuntu-latest` runner (which has `file`
preinstalled) and never builds the Dockerfile.

- Add `file` to the builder stage's apt deps.
- Add a `docker-build` CI job so the headless image build is actually exercised.

Verified locally: `docker build -t asid-vice:latest .` now succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)