### PR TITLE
ci: publish full-feature X11 image to Docker Hub on v* tags

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,42 @@
+---
+name: release
+# Publish the X11 (GTK3) image to Docker Hub on every `v*` tag
+# (e.g. v3.10.0.0). Requires repository secrets DOCKER_USERNAME and
+# DOCKER_TOKEN.
+on:
+  push:
+    tags:
+      # Version tags like v3.10.0.0 — the leading digit avoids matching the
+      # old `vice-*` tags.
+      - 'v[0-9]*'
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          submodules: recursive
+
+      - name: Derive image version
+        id: ver
+        # Strip the leading "v" so v3.10.0.0 -> 3.10.0.0.
+        run: echo "version=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
+
+      - uses: docker/setup-buildx-action@v3
+
+      - uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_TOKEN }}
+
+      - uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: Dockerfile.x11
+          push: true
+          tags: |
+            ${{ secrets.DOCKER_USERNAME }}/asid-vice:${{ steps.ver.outputs.version }}
+            ${{ secrets.DOCKER_USERNAME }}/asid-vice:latest
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,3 +22,14 @@ jobs:
           submodules: recursive
       - name: docker build
         run: docker build -t asid-vice:latest .
+
+  docker-build-x11:
+    # Build the X11 (GTK3, full-feature) image that release.yml publishes, so
+    # the Dockerfile.x11 build stays exercised on every push/PR without pushing.
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          submodules: recursive
+      - name: docker build x11
+        run: docker build -f Dockerfile.x11 -t asid-vice:x11 .

--- a/Dockerfile.x11
+++ b/Dockerfile.x11
@@ -1,0 +1,156 @@
+# asid-vice X11 (GTK3) image — the build published to Docker Hub.
+#
+# Unlike the headless `Dockerfile`, this builds the full GTK3 (X11) UI with the
+# widest practical set of VICE options enabled: reSID + HardSID + ParSID sound,
+# ASID-over-MIDI (ALSA), emulated MIDI cartridge, The Final Ethernet (libpcap),
+# every audio codec VICE can use (FLAC / Ogg-Vorbis / MP3 decode via mpg123 /
+# MP3 encode via LAME), PNG + GIF screenshots, libcurl, and ffmpeg video
+# capture (the driver shells out to the `ffmpeg` binary at runtime).
+#
+# Multi-stage: the builder compiles + `make install`s VICE into /opt/vice; the
+# runtime stage carries only that tree plus the shared libraries the binaries
+# link, keeping the published image small.
+#
+# The GTK3 UI needs an X server. The entrypoint auto-starts Xvfb when no
+# DISPLAY is provided, so the image runs in a bare container out of the box;
+# bind-mount the host X socket and pass -e DISPLAY to show a real window.
+#
+# Build:
+#   docker build -f Dockerfile.x11 -t asid-vice:x11 .
+#
+# Run (virtual framebuffer, binmon on 6502):
+#   docker run --rm -p 6502:6502 asid-vice:x11
+#
+# Run showing a window on the host X server:
+#   docker run --rm -e DISPLAY -v /tmp/.X11-unix:/tmp/.X11-unix \
+#       -p 6502:6502 asid-vice:x11
+
+# ---------------------------------------------------------------------------
+# Stage 1: build
+# ---------------------------------------------------------------------------
+FROM debian:bookworm-slim AS builder
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Toolchain + every -dev package needed to turn the configure options below
+# on. GTK3 pulls in GLEW/OpenGL (rendering) and libglib2.0-dev-bin (the
+# glib-compile-resources / glib-genmarshal tools the GTK build invokes). `file`
+# is required by src/Makefile.am's infocontrib.h rule.
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        autoconf \
+        automake \
+        build-essential \
+        byacc \
+        ca-certificates \
+        dos2unix \
+        file \
+        flex \
+        libasound2-dev \
+        libcurl4-openssl-dev \
+        libevdev-dev \
+        libflac-dev \
+        libgif-dev \
+        libglew-dev \
+        libglib2.0-dev \
+        libglib2.0-dev-bin \
+        libgtk-3-dev \
+        libieee1284-3-dev \
+        libmp3lame-dev \
+        libmpg123-dev \
+        libpcap-dev \
+        libpng-dev \
+        libpulse-dev \
+        libvorbis-dev \
+        pkg-config \
+        texinfo \
+        xa65 \
+        zlib1g-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /src
+COPY . /src
+
+# --prefix=/opt/vice so the runtime stage copies one self-contained tree.
+# PNG, libcurl, PulseAudio, reSID, HardSID and cpu-history are on by default;
+# the flags below add the GTK3 UI and the remaining optional features.
+RUN ./autogen.sh \
+    && ./configure \
+        --prefix=/opt/vice \
+        --enable-gtk3ui \
+        --with-alsa \
+        --enable-midi \
+        --enable-ethernet \
+        --enable-parsid \
+        --with-libieee1284 \
+        --with-flac \
+        --with-vorbis \
+        --with-mpg123 \
+        --with-lame \
+        --with-gif \
+        --disable-html-docs \
+        --disable-realdevice \
+    && make -j"$(nproc)" \
+    && make install \
+    && (strip /opt/vice/bin/* || true)
+
+# ---------------------------------------------------------------------------
+# Stage 2: runtime
+# ---------------------------------------------------------------------------
+FROM debian:bookworm-slim AS runtime
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Runtime shared libraries the installed binaries link against, plus Xvfb (so
+# the GTK3 UI runs without a host X server) and ffmpeg (video capture driver).
+# libgtk-3-0 pulls in the Pango/Cairo/gdk-pixbuf stack transitively.
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        ffmpeg \
+        libasound2 \
+        libcurl4 \
+        libevdev2 \
+        libflac12 \
+        libgif7 \
+        libgl1-mesa-dri \
+        libglew2.2 \
+        libglib2.0-0 \
+        libgtk-3-0 \
+        libieee1284-3 \
+        libmp3lame0 \
+        libmpg123-0 \
+        libpcap0.8 \
+        libpng16-16 \
+        libpulse0 \
+        libvorbis0a \
+        libvorbisenc2 \
+        xauth \
+        xvfb \
+        zlib1g \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY --from=builder /opt/vice /opt/vice
+COPY docker/x11-entrypoint.sh /usr/local/bin/x11-entrypoint.sh
+RUN chmod +x /usr/local/bin/x11-entrypoint.sh
+
+ENV PATH=/opt/vice/bin:$PATH
+
+# VICE writes its config/state/log under these; pre-create so a fresh run does
+# not fail trying to create them.
+RUN mkdir -p /root/.config/vice /root/.local/state/vice /root/.cache/vice
+
+# Working directory for mounting disk/prg/snapshot images.
+WORKDIR /work
+
+# Binary monitor port. Use `-p 6502:6502` on `docker run` to expose it.
+EXPOSE 6502
+
+# x11-entrypoint.sh brings up Xvfb (unless DISPLAY is already set) then execs
+# the CMD. Extra `docker run` arguments replace the CMD and are passed to
+# x64sc (e.g. `-autostart /work/foo.d64`).
+ENTRYPOINT ["/usr/local/bin/x11-entrypoint.sh"]
+CMD [ \
+    "x64sc", \
+    "-default", \
+    "-warp", \
+    "-binarymonitor", \
+    "-binarymonitoraddress", "ip4://0.0.0.0:6502" \
+]

--- a/README.md
+++ b/README.md
@@ -7,36 +7,51 @@ originally posted as a patch in http://midibox.org/forums/topic/17538-vice-emula
 This allows VICE to command an Elektron SIDStation, or a C64 with a Vessel interface and [VAP](https://github.com/anarkiwi/vap),
 or a C64 with a regular MIDI interface and [Station64](https://csdb.dk/release/?id=142049).  ASID isn't fast enough for sample playback.
 
-## Building
-### Installing build dependencies
+## Docker image
+
+The published image (`anarkiwi/asid-vice` on Docker Hub) is built from
+[`Dockerfile.x11`](Dockerfile.x11): the full **GTK3 (X11) VICE** with the widest
+practical set of options enabled — reSID + HardSID + ParSID, ASID-over-MIDI and
+the emulated MIDI cartridge, The Final Ethernet, FLAC / Ogg-Vorbis / MP3
+(mpg123 decode, LAME encode), PNG + GIF screenshots, libcurl, and `ffmpeg`
+video capture. It is a multi-stage build, so the runtime image carries only the
+binaries, ROMs and shared libraries. Each `v*` release tag (e.g. `v3.10.0.0`)
+publishes it via
+[`.github/workflows/release.yml`](.github/workflows/release.yml), which needs
+the repo secrets `DOCKER_USERNAME` and `DOCKER_TOKEN`.
+
+### Pull from Docker Hub
 ```
-sudo apt update && sudo apt install \
-	autoconf \
-	build-essential \
-	byacc \
-	dos2unix \
-	flex \
-	libasound2-dev \
-	libevdev-dev \
-	libglew-dev \
-	libglib2.0-dev \
-	libpng-dev \
-	libsdl2-dev \
-	libsdl2-image-dev \
-	texinfo \
-	texmaker \
-	xa65
+docker pull anarkiwi/asid-vice:latest
 ```
 
-### Compiling 
+### Build locally
 ```
-./autogen.sh && ./configure --with-alsa && make -j
+docker build -f Dockerfile.x11 -t asid-vice:x11 .
 ```
 
-### Installing
+### Running X11 inside a container
+
+The GTK3 UI needs an X server. The entrypoint auto-starts `Xvfb` when no
+`DISPLAY` is set, so the image runs in a bare container out of the box; the
+binary monitor is exposed on TCP `6502`.
 ```
-sudo make install
+# Virtual framebuffer, no host X server needed
+docker run --rm -p 6502:6502 anarkiwi/asid-vice:latest
+
+# Show a real window on the host X server (Linux)
+docker run --rm -e DISPLAY -v /tmp/.X11-unix:/tmp/.X11-unix \
+    -p 6502:6502 anarkiwi/asid-vice:latest
+
+# Autostart a disk/prg by mounting it (extra args replace the default CMD,
+# so start them with the emulator binary):
+docker run --rm -p 6502:6502 -v "$PWD/Commando.d64:/work/disk.d64:ro" \
+    anarkiwi/asid-vice:latest x64sc -autostart /work/disk.d64
 ```
+
+For ASID over a real MIDI device, pass the host ALSA devices through with
+`--device /dev/snd` and select the port with `-sounddev asid -soundarg <n>`
+(see below).
 
 ## Running
 To enable the asid output, use the `-sounddev asid` command line option.
@@ -125,6 +140,8 @@ so a freshly-started container is already listening for binmon
 clients. From there your app can `keymatrix tap` to feed input and
 `screenscrape` (`SCREEN_GET`) to read the display every frame —
 nothing in the data path requires a display, X server, or audio device.
+This minimal `Dockerfile` is the alternative to the published X11 image
+([Docker image](#docker-image) above) when all you need is binmon driving.
 
 ---
 

--- a/docker/x11-entrypoint.sh
+++ b/docker/x11-entrypoint.sh
@@ -1,0 +1,21 @@
+#!/bin/sh
+# Entrypoint for the X11 (GTK3) asid-vice image.
+#
+# The GTK3 UI needs an X server. If the caller supplies one (DISPLAY set,
+# e.g. the host X socket bind-mounted in), use it as-is. Otherwise start a
+# virtual framebuffer (Xvfb) so the emulator runs in a bare container with no
+# host X server, then exec the requested command against it.
+set -e
+
+if [ -z "$DISPLAY" ]; then
+    export DISPLAY=:99
+    Xvfb "$DISPLAY" -screen 0 1280x1024x24 -nolisten tcp >/dev/null 2>&1 &
+    # Wait for the X socket to appear before starting the GTK client.
+    i=0
+    while [ ! -e /tmp/.X11-unix/X99 ] && [ "$i" -lt 50 ]; do
+        i=$((i + 1))
+        sleep 0.1
+    done
+fi
+
+exec "$@"


### PR DESCRIPTION
## What

Adds Docker Hub publishing of the package, plus a full-feature X11 (GTK3) release image.

### `Dockerfile.x11` — the published image
Multi-stage GTK3 (X11) build with the widest practical VICE option set enabled:
- reSID + HardSID + ParSID sound
- ASID-over-MIDI (ALSA) + emulated MIDI cartridge
- The Final Ethernet (libpcap)
- FLAC / Ogg-Vorbis / MP3 (mpg123 decode, LAME encode)
- PNG + GIF screenshots, libcurl, and `ffmpeg` video capture

The runtime stage carries only binaries, ROMs and the shared libraries the
binaries link (image ~640 MB). `docker/x11-entrypoint.sh` auto-starts `Xvfb`
when no `DISPLAY` is provided, so the GTK3 UI runs in a bare container out of
the box; bind-mount the host X socket + `-e DISPLAY` for a real window.

### `.github/workflows/release.yml`
Publishes `anarkiwi/asid-vice:<version>` and `:latest` to Docker Hub on
`v[0-9]*` tags (first release `v3.10.0.0`), using repo secrets
`DOCKER_USERNAME` and `DOCKER_TOKEN`. The `v[0-9]*` glob avoids matching the
old `vice-*` tags.

### `test.yml`
Adds a build-only `docker-build-x11` job so `Dockerfile.x11` stays exercised on
every push/PR (no push).

### README
Reworked: bespoke manual apt/configure/make steps replaced with Docker
build/pull instructions and how to run X11 inside a container.

## Verification
Built `Dockerfile.x11` locally and ran the image end-to-end:
- All target drivers compiled in (ASID, FLAC, GIF, Ogg/Vorbis, ffmpeg, ParSID, reSID)
- Entrypoint starts Xvfb, GTK3 `x64sc` runs, binmon listens on `6502`

## Follow-up (not in this PR)
Per the release plan, the old `vice-*` tags/releases are to be removed and
`v3.10.0.0` created — a destructive remote operation left for maintainer
confirmation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PogSRVYxpD3YCdKi6ZSccA